### PR TITLE
Add support for ca config

### DIFF
--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -1,5 +1,7 @@
 var _ = require('lodash'),
   async = require('async'),
+  fs = require('fs'),
+  path = require('path'),
   semver = require('semver'),
   request = require('request');
 
@@ -26,9 +28,14 @@ function RemoteLS(opts) {
 }
 
 RemoteLS.prototype._loadPackageJson = function(task, done) {
-  var _this = this;
+  var _this = this,
+      config = {
+        json: true
+      };
 
-  request.get(this.registry.replace(/\/$/, '') + '/' + task.name, {json: true}, function(err, res, obj) {
+  config.ca = this.ca ? fs.readFileSync(path.resolve(this.ca)) : undefined;
+
+  request.get(this.registry.replace(/\/$/, '') + '/' + task.name, config, function(err, res, obj) {
     if (err || (res.statusCode < 200 || res.statusCode >= 400)) {
       var message = res ? 'status = ' + res.statusCode : 'error = ' + err.message;
       _this.logger.log(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-remote-ls",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Examine a package's dependency graph before you install it",
   "main": "./lib/index.js",
   "bin": {


### PR DESCRIPTION
I realize this repo hasn't been touched in a year or so, but I'm stuck on a network that uses a self-signed certificate... Adding support for the `ca` config allows me to set this and avoid errors like `could not load module@version error = self signed certificate in certificate chain`. 

Sample usage:


```javascript
var RemoteLS = new require('npm-remote-ls').RemoteLS;
var ls = new RemoteLS({
  ca: '/path/to/certificate.pem'
});

ls.ls('grunt', 'latest', function() {
  console.log(Object.keys(ls.flat));
});
```