### PR TITLE
move tests from lab to tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules
+.nyc_output/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: node_js
+sudo: false
+before_install: npm -g install npm
 node_js:
-  - "0.11"
   - "0.10"
+  - "0.12"
+  - "iojs"
+  - "4"
+  - "5"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm-remote-ls": "./bin/npm-remote-ls.js"
   },
   "scripts": {
-    "test": "standard && lab -c --timeout 2000"
+    "test": "standard && tap --coverage test"
   },
   "repository": {
     "type": "git",
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/npm/npm-remote-ls",
   "devDependencies": {
-    "lab": "^4.6.2",
     "nock": "^0.48.1",
-    "standard": "^5.4.1"
+    "standard": "^5.4.1",
+    "tap": "^2.3.1"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/test/remote-ls-test.js
+++ b/test/remote-ls-test.js
@@ -1,84 +1,89 @@
-var Lab = require('lab')
-var lab = exports.lab = Lab.script()
+var test = require('tap').test
 var nock = require('nock')
 var fs = require('fs')
 var RemoteLS = require('../lib/remote-ls')
 
-lab.experiment('RemoteLS', function () {
-  lab.experiment('guessVersion', function () {
-    lab.it('should handle an exact version being provided', function (done) {
+test('RemoteLS', function (t) {
+  t.test('guessVersion', function (t) {
+    t.test('should handle an exact version being provided', function (t) {
       var versionString = '1.0.0'
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
       var ls = new RemoteLS()
 
-      Lab.expect(
-        ls._guessVersion(versionString, packageJson)
-      ).to.eql('1.0.0')
-
-      done()
+      t.equal(
+        ls._guessVersion(versionString, packageJson),
+        '1.0.0'
+      )
+      t.end()
     })
 
-    lab.it('should handle a complex version being provided', function (done) {
+    t.test('should handle a complex version being provided', function (t) {
       var versionString = '*'
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
       var ls = new RemoteLS()
 
-      Lab.expect(
-        ls._guessVersion(versionString, packageJson)
-      ).to.eql('3.0.1')
-
-      done()
+      t.equal(
+        ls._guessVersion(versionString, packageJson),
+        '3.0.1'
+      )
+      t.end()
     })
 
-    lab.it('should raise an exception if version cannot be found', function (done) {
+    t.test('should raise an exception if version cannot be found', function (t) {
       var versionString = '9.0.0'
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
       var ls = new RemoteLS()
 
-      Lab.expect(function () {
-        ls._guessVersion(versionString, packageJson)
-      }).to.throw(/could not find a satisfactory version/)
-
-      done()
+      t.throws(
+        function () {
+          ls._guessVersion(versionString, packageJson)
+        },
+        /could not find a satisfactory version/
+      )
+      t.end()
     })
 
-    lab.it('should raise an exception if version cannot be found', function (done) {
+    t.test('should raise an exception if version cannot be found', function (t) {
       var versionString = '9.0.0'
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
       var ls = new RemoteLS()
 
-      Lab.expect(function () {
-        ls._guessVersion(versionString, packageJson)
-      }).to.throw(/could not find a satisfactory version/)
-
-      done()
+      t.throws(
+        function () {
+          ls._guessVersion(versionString, packageJson)
+        },
+        /could not find a satisfactory version/
+      )
+      t.end()
     })
 
-    lab.it('should handle "latest" being provided as version', function (done) {
+    t.test('should handle "latest" being provided as version', function (t) {
       var versionString = 'latest'
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
       var ls = new RemoteLS()
 
-      Lab.expect(
-        ls._guessVersion(versionString, packageJson)
-      ).to.eql('3.0.1')
-
-      done()
+      t.equal(
+        ls._guessVersion(versionString, packageJson),
+        '3.0.1'
+      )
+      t.end()
     })
+
+    t.end()
   })
 
-  lab.experiment('_walkDependencies', function () {
-    lab.it('should push appropriate dependencies to queue', function (done) {
+  t.test('_walkDependencies', function (t) {
+    t.test('should push appropriate dependencies to queue', function (t) {
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
@@ -86,9 +91,9 @@ lab.experiment('RemoteLS', function () {
         queue: {
           pause: function () {},
           push: function (obj) {
-            Lab.expect(obj.name).to.eql('abbrev')
-            Lab.expect(obj.version).to.eql('1')
-            done()
+            t.equal(obj.name, 'abbrev')
+            t.equal(obj.version, '1')
+            t.end()
           }
         }
       })
@@ -100,7 +105,7 @@ lab.experiment('RemoteLS', function () {
       }, packageJson, function () {})
     })
 
-    lab.it('should push devDependencies to queue', function (done) {
+    t.test('should push devDependencies to queue', function (t) {
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
@@ -108,9 +113,9 @@ lab.experiment('RemoteLS', function () {
         queue: {
           pause: function () {},
           push: function (obj) {
-            Lab.expect(obj.name).to.eql('tap')
-            Lab.expect(obj.version).to.eql('1.0.0')
-            done()
+            t.equal(obj.name, 'tap')
+            t.equal(obj.version, '1.0.0')
+            t.end()
           }
         }
       })
@@ -122,22 +127,24 @@ lab.experiment('RemoteLS', function () {
       }, packageJson, function () {})
     })
 
-    lab.it('should not raise an exception if package has no dependencies', function (done) {
+    t.test('should not raise an exception if package has no dependencies', function (t) {
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/abbrev.json').toString()
       )
       var ls = new RemoteLS()
 
-      ls._walkDependencies({
-        name: 'abbrev',
-        version: '*',
-        parent: {}
-      }, packageJson, function () {})
+      t.doesNotThrow(function () {
+        ls._walkDependencies({
+          name: 'abbrev',
+          version: '*',
+          parent: {}
+        }, packageJson, function () {})
+      })
 
-      done()
+      t.end()
     })
 
-    lab.it('should not walk dependency if dependency has already been observed', function (done) {
+    t.test('should not walk dependency if dependency has already been observed', function (t) {
       var packageJson = JSON.parse(
         fs.readFileSync('./test/fixtures/nopt.json').toString()
       )
@@ -148,9 +155,8 @@ lab.experiment('RemoteLS', function () {
         queue: {
           pause: function () {},
           push: function (obj) {
-            Lab.expect(obj.name).to.eql('tap')
-            Lab.expect(obj.version).to.eql('1.0.0')
-            done()
+            t.fail('should not walk dependency')
+            t.end()
           }
         }
       })
@@ -161,12 +167,14 @@ lab.experiment('RemoteLS', function () {
         parent: {}
       }, packageJson, function () {})
 
-      done()
+      t.end()
     })
+
+    t.end()
   })
 
-  lab.experiment('ls', function () {
-    lab.it('handles a 404 and prints an appropriate message', function (done) {
+  t.test('ls', function (t) {
+    t.test('handles a 404 and prints an appropriate message', function (t) {
       nock('https://skimdb.npmjs.com')
           .get('/registry/request')
           .reply(404)
@@ -174,13 +182,17 @@ lab.experiment('RemoteLS', function () {
         registry: 'https://skimdb.npmjs.com/registry/',
         logger: {
           log: function (msg) {
-            Lab.expect(msg).to.match(/status = 404/)
-            done()
+            t.match(msg, /status = 404/)
+            t.end()
           }
         }
       })
 
       ls.ls('request', '*', function () {})
     })
+
+    t.end()
   })
+
+  t.end()
 })


### PR DESCRIPTION
I figured you put all that work into `nyc`, might as well take advantage of it. As much as possible, I tried to preserve the existing nested structure of the tests. I changed two expectations to a `t.fail()` to make it better mirror the intent of the tests, though.

**r**: @bcoe