### PR TITLE
add documentation, fixed bug found while writing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm install npm-remote-ls -g
 
 ## Usage
 
+### Listing Package Dependencies
+
 ```
 npm-remote-ls sha@1.2.4
 
@@ -23,6 +25,15 @@ npm-remote-ls sha@1.2.4
    │  ├─ inherits@2.0.1
    │  └─ core-util-is@1.0.1
    └─ graceful-fs@3.0.2
+```
+
+### Help!
+
+There are various command line flags you can toggle for `npm-remote-ls`, for
+details run:
+
+```bash
+npm-remote-ls --help
 ```
 
 ## API
@@ -56,3 +67,23 @@ ls('grunt', '0.1.0', true, function(obj) {
   console.log(obj);
 });
 ```
+
+**Configure to only return production dependencies:**
+
+```javascript
+var ls = require('npm-remote-ls').ls
+var config = require('npm-remote-ls').config
+
+config({
+  development: false,
+  optional: false
+})
+
+ls('yargs', 'latest', true, function (obj) {
+  console.log(obj)
+})
+```
+
+## License
+
+ISC

--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -14,7 +14,7 @@ function RemoteLS (opts) {
     development: true, // include dev dependencies.
     optional: true, // include optional dependencies.
     verbose: false,
-    registry: require('registry-url'), // URL of registry to ls.
+    registry: require('registry-url')(), // URL of registry to ls.
     queue: async.queue(function (task, done) {
       _this._loadPackageJson(task, done)
     }, 8),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/npm/npm-remote-ls",
   "devDependencies": {
+    "chai": "^3.5.0",
     "nock": "^8.0.0",
     "standard": "^6.0.8",
     "tap": "^5.7.1"


### PR DESCRIPTION
* we were not appropriate defaulting the registry-URL (I noticed this while writing documentation for how to configure npm-remote-ls).
* I added a test-case for the above bug, along with a test case for the happy-path of npm-remote-ls.
* adds documentation that addresses the issues in #10.