### PR TITLE
fix: uri-encode slash in package name to support scopes

### DIFF
--- a/bin/npm-remote-ls.js
+++ b/bin/npm-remote-ls.js
@@ -44,6 +44,7 @@ var argv = yargs.argv
 var ls = require('../lib').ls
 var treeify = require('treeify')
 var spinner = require('char-spinner')
+var npa = require('npm-package-arg')
 
 require('../lib').config({
   verbose: argv.verbose,
@@ -53,13 +54,13 @@ require('../lib').config({
 })
 
 var name = argv.name || argv._[0] || ''
-var version = name.split('@')[1] || argv.version
 
 if (argv.help || !name) {
   yargs.showHelp()
 } else {
   spinner()
-  ls(name.split('@')[0], version, argv.flatten, function (obj) {
+  var parsed = npa(name)
+  ls(parsed.name, parsed.rawSpec || argv.version, argv.flatten, function (obj) {
     if (Array.isArray(obj)) console.log(obj)
     else console.log(treeify.asTree(obj))
   })

--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -3,6 +3,7 @@ var async = require('async')
 var semver = require('semver')
 var request = require('request')
 var once = require('once')
+var npa = require('npm-package-arg')
 
 // perform a recursive walk of a remote
 // npm package and determine its dependency
@@ -31,9 +32,7 @@ RemoteLS.prototype._loadPackageJson = function (task, done) {
   var name = task.name
 
   // account for scoped packages like @foo/bar
-  // TODO replace couchPackageName with npa(name).escapedName when this is published:
-  // https://github.com/npm/npm-package-arg/pull/18
-  var couchPackageName = name && name.replace('/', '%2f')
+  var couchPackageName = name && npa(name).escapedName
 
   // wrap done so it's only called once
   // if done throws in _walkDependencies, it will be called again in catch below

--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -25,20 +25,39 @@ function RemoteLS (opts) {
   this.queue.pause()
 }
 
-RemoteLS.prototype._loadPackageJson = function (task, done) {
+RemoteLS.prototype._loadPackageJson = function (task, doneForReal) {
   var _this = this
+  var name = task.name
 
-  request.get(this.registry.replace(/\/$/, '') + '/' + task.name, {json: true}, function (err, res, obj) {
+  // account for scoped packages like @foo/bar
+  // TODO replace couchPackageName with npa(name).escapedName when this is published:
+  // https://github.com/npm/npm-package-arg/pull/18
+  var couchPackageName = name && name.replace('/', '%2f')
+
+  // wrap doneForReal so it's only called once
+  // if done throws in _walkDependencies, it will be called again in catch below
+  // we want to avoid "Callback was already called." from async
+  var doneCalled = false
+  var doneForRealResult
+  var done = function () {
+    if (!doneCalled) {
+      doneCalled = true
+      doneForRealResult = doneForReal()
+    }
+    return doneForRealResult
+  }
+
+  request.get(this.registry.replace(/\/$/, '') + '/' + couchPackageName, {json: true}, function (err, res, obj) {
     if (err || (res.statusCode < 200 || res.statusCode >= 400)) {
       var message = res ? 'status = ' + res.statusCode : 'error = ' + err.message
       _this.logger.log(
-        'could not load ' + task.name + '@' + task.version + ' ' + message
+        'could not load ' + name + '@' + task.version + ' ' + message
       )
       return done()
     }
 
     try {
-      if (_this.verbose) console.log('loading:', task.name + '@' + task.version)
+      if (_this.verbose) console.log('loading:', name + '@' + task.version)
       _this._walkDependencies(task, obj, done)
     } catch (e) {
       _this.logger.log(e.message)

--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -2,6 +2,7 @@ var _ = require('lodash')
 var async = require('async')
 var semver = require('semver')
 var request = require('request')
+var once = require('once')
 
 // perform a recursive walk of a remote
 // npm package and determine its dependency
@@ -25,7 +26,7 @@ function RemoteLS (opts) {
   this.queue.pause()
 }
 
-RemoteLS.prototype._loadPackageJson = function (task, doneForReal) {
+RemoteLS.prototype._loadPackageJson = function (task, done) {
   var _this = this
   var name = task.name
 
@@ -34,18 +35,10 @@ RemoteLS.prototype._loadPackageJson = function (task, doneForReal) {
   // https://github.com/npm/npm-package-arg/pull/18
   var couchPackageName = name && name.replace('/', '%2f')
 
-  // wrap doneForReal so it's only called once
+  // wrap done so it's only called once
   // if done throws in _walkDependencies, it will be called again in catch below
   // we want to avoid "Callback was already called." from async
-  var doneCalled = false
-  var doneForRealResult
-  var done = function () {
-    if (!doneCalled) {
-      doneCalled = true
-      doneForRealResult = doneForReal()
-    }
-    return doneForRealResult
-  }
+  done = once(done)
 
   request.get(this.registry.replace(/\/$/, '') + '/' + couchPackageName, {json: true}, function (err, res, obj) {
     if (err || (res.statusCode < 200 || res.statusCode >= 400)) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "async": "^2.0.0-rc.3",
     "char-spinner": "^1.0.1",
     "lodash": "^4.10.0",
+    "npm-package-arg": "^4.1.1",
     "once": "^1.3.3",
     "registry-url": "^3.0.3",
     "request": "^2.37.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "async": "^2.0.0-rc.3",
     "char-spinner": "^1.0.1",
     "lodash": "^4.10.0",
+    "once": "^1.3.3",
     "registry-url": "^3.0.3",
     "request": "^2.37.0",
     "semver": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async": "^2.0.0-rc.3",
     "char-spinner": "^1.0.1",
     "lodash": "^4.10.0",
-    "npm-package-arg": "^4.1.1",
+    "npm-package-arg": "^4.2.0",
     "once": "^1.3.3",
     "registry-url": "^3.0.3",
     "request": "^2.37.0",

--- a/test/remote-ls-test.js
+++ b/test/remote-ls-test.js
@@ -242,6 +242,47 @@ test('RemoteLS', function (t) {
       })
     })
 
+    t.test('supports scoped packages', function (t) {
+      var storybook = nock('https://registry.npmjs.org')
+          .get('/@kadira%2fstorybook')
+          .reply(200, {
+            name: '@kadira/storybook',
+            versions: {
+              '1.30.0': {
+                dependencies: { '@kadira/storybook-core': '1.27.0' }
+              }
+            }
+          })
+      var storybook404 = nock('https://registry.npmjs.org')
+          .get('/@kadira/storybook')
+          .reply(404, {
+            error: 'Not found'
+          })
+      var core = nock('https://registry.npmjs.org')
+          .get('/@kadira%2fstorybook-core')
+          .reply(200, {
+            name: '@kadira/storybook-core',
+            versions: {
+              '1.27.0': { dependencies: {} }
+            }
+          })
+      var core404 = nock('https://registry.npmjs.org')
+          .get('/@kadira/storybook-core')
+          .reply(404, {
+            error: 'Not found'
+          })
+      var ls = new RemoteLS()
+
+      ls.ls('@kadira/storybook', '*', function (res) {
+        res.should.deep.equal({ '@kadira/storybook@1.30.0': { '@kadira/storybook-core@1.27.0': {} } })
+        storybook.done()
+        core.done()
+        t.notOk(storybook404.isDone())
+        t.notOk(core404.isDone())
+        t.end()
+      })
+    })
+
     t.end()
   })
 


### PR DESCRIPTION
Fixes #24.

Note that if/when https://github.com/npm/npm-package-arg/pull/18 lands and is published, we should replace this line:

```js
var couchPackageName = name && name.replace('/', '%2f')
```

with something like this:

```js
var couchPackageName = name && require('npm-package-arg')(name).escapedName
```

so that escaping logic can be centralized/reused.