### PR TITLE
Remove optional dependencies from the list of deps

### DIFF
--- a/lib/remote-ls.js
+++ b/lib/remote-ls.js
@@ -62,9 +62,20 @@ RemoteLS.prototype._loadPackageJson = function (task, done) {
 RemoteLS.prototype._walkDependencies = function (task, packageJson, done) {
   var _this = this
   var version = this._guessVersion(task.version, packageJson)
+  var mandatoryDependencies = packageJson.versions[version].dependencies
+  // Remove the optionalDependencies from the list of optional + regular
+  // dependencies coming from the registry
+  if (packageJson.versions[version].optionalDependencies !== undefined) {
+    Object.keys(packageJson.versions[version].optionalDependencies).forEach(function (optionalDep) {
+      if (Object.keys(mandatoryDependencies).indexOf(optionalDep) > -1) {
+        delete mandatoryDependencies[optionalDep]
+      }
+    })
+  }
+
   var dependencies = _.extend(
     {},
-    packageJson.versions[version].dependencies,
+    mandatoryDependencies,
     this.optional ? packageJson.versions[version].optionalDependencies : {},
     this.peer ? packageJson.versions[version].peerDependencies : {},
     // show development dependencies if we're at the root, and deevelopment flag is true.


### PR DESCRIPTION
npm-remote-ls relies on the registry to list dependencies. The registry
is currently listing both regular and optional dependencies altogether,
so the '--optional' option does nothing right now.

To fix it, I removed the optional dependencies from the list of
dependencies after getting the JSON.

Check the JSON returned by the registry to see how optional dependencies
are included in the list of dependencie

https://registry.npmjs.org/compression-webpack-plugin/0.3.2
https://registry.npmjs.org/chokidar/1.6.1

To reproduce the bug. simply run

```
bin/npm-remote-ls.js -n compression-webpack-plugin -o false -v 0.3.1
```

and notice how optional dependencies are listed even with -o false.

Asking because https://github.com/dlobatog/npm2rpm relies on this to generate a proper RPM with the right dependencies 😄 