### PR TITLE
Don't truncate flatten'd output to 101 items

### DIFF
--- a/bin/npm-remote-ls.js
+++ b/bin/npm-remote-ls.js
@@ -68,7 +68,9 @@ if (argv.help || !name) {
   spinner()
   var parsed = npa(name)
   ls(parsed.name, parsed.rawSpec || argv.version, argv.flatten, function (obj) {
-    if (Array.isArray(obj)) console.log(obj)
-    else console.log(treeify.asTree(obj))
+    if (Array.isArray(obj)) {
+      require('util').inspect.defaultOptions.maxArrayLength = null
+      console.log(obj)
+    } else console.log(treeify.asTree(obj))
   })
 }


### PR DESCRIPTION
Since nodejs version v6.4.0, console.log output for Array
objects is truncated to 101 items.  This outputs a non-valid
list, which is unparsable and of less use.

This change sets the maxArrayLength to null, which means
that all items are outputted when a -f / --flatten output is
requested.

Closes npm/npm-remote-ls#33
Signed-off-by: Dave Walker (Daviey) <email@daviey.com>