### PR TITLE
Show complete flattened list

### DIFF
--- a/bin/npm-remote-ls.js
+++ b/bin/npm-remote-ls.js
@@ -68,7 +68,7 @@ if (argv.help || !name) {
   spinner()
   var parsed = npa(name)
   ls(parsed.name, parsed.rawSpec || argv.version, argv.flatten, function (obj) {
-    if (Array.isArray(obj)) console.log(obj)
+    if (Array.isArray(obj)) console.log(JSON.stringify(obj, null, 2))
     else console.log(treeify.asTree(obj))
   })
 }


### PR DESCRIPTION
The flattened list gets truncated for packages with a large number of dependencies. This change serializes the list in a way that shows all the elements.

For example, the dependencies list for cypress is truncated, and a part of the list is shown as `  ... 73 more items`

$ npx npm-remote-ls --flatten  cypress
[
  'cypress@7.6.0',
  'arch@2.2.0',
  '@types/sizzle@2.3.3',
  '@types/sinonjs__fake-timers@6.0.2',
  '@cypress/xvfb@1.2.4',
  'blob-util@2.0.2',
  '@cypress/request@2.88.5',
  'bluebird@3.7.2',
  'cachedir@2.3.0',
  'cli-cursor@3.1.0',
  'chalk@4.1.1',
  'cli-table3@0.6.0',
  'check-more-types@2.24.0',
  'common-tags@1.8.0',
  'debug@4.3.2',
  'eventemitter2@6.4.4',
  'enquirer@2.3.6',
  'dayjs@1.10.5',
  'commander@5.1.0',
  'executable@4.1.1',
  'execa@4.1.0',
  'figures@3.2.0',
  'extract-zip@2.0.1',
  'is-ci@3.0.0',
  'getos@3.2.1',
  'is-installed-globally@0.4.0',
  'fs-extra@9.1.0',
  'ospath@1.2.2',
  '@types/node@14.17.4',
  'log-symbols@4.1.0',
  'minimist@1.2.5',
  'lodash@4.17.21',
  'pretty-bytes@5.6.0',
  'request-progress@3.0.0',
  'untildify@4.0.0',
  'ramda@0.27.1',
  'tmp@0.2.1',
  'supports-color@8.1.1',
  'url@0.11.0',
  'lazy-ass@1.6.0',
  'yauzl@2.10.0',
  'aws-sign2@0.7.0',
  'listr2@3.10.0',
  'caseless@0.12.0',
  'lodash.once@4.1.1',
  'aws4@1.11.0',
  'debug@3.2.7',
  'forever-agent@0.6.1',
  'extend@3.0.2',
  'combined-stream@1.0.8',
  'is-typedarray@1.0.0',
  'http-signature@1.2.0',
  'form-data@2.3.3',
  'isstream@0.1.2',
  'har-validator@5.1.5',
  'json-stringify-safe@5.0.1',
  'oauth-sign@0.9.0',
  'performance-now@2.1.0',
  'mime-types@2.1.31',
  'safe-buffer@5.2.1',
  'tunnel-agent@0.6.0',
  'tough-cookie@2.5.0',
  'qs@6.5.2',
  'restore-cursor@3.1.0',
  'uuid@3.4.0',
  'object-assign@4.1.1',
  'string-width@4.2.2',
  'ansi-styles@4.3.0',
  'supports-color@7.2.0',
  'ms@2.1.2',
  'colors@1.4.0',
  'ansi-colors@4.1.1',
  'pify@2.3.0',
  'is-stream@2.0.0',
  'human-signals@1.1.1',
  'get-stream@5.2.0',
  'merge-stream@2.0.0',
  'cross-spawn@7.0.3',
  'npm-run-path@4.0.1',
  'onetime@5.1.2',
  'strip-final-newline@2.0.0',
  'signal-exit@3.0.3',
  'escape-string-regexp@1.0.5',
  '@types/yauzl@2.9.1',
  'ci-info@3.2.0',
  'global-dirs@3.0.0',
  'is-path-inside@3.0.3',
  'at-least-node@1.0.0',
  'async@3.2.0',
  'jsonfile@6.1.0',
  'universalify@2.0.0',
  'graceful-fs@4.2.6',
  'is-unicode-supported@0.1.0',
  'throttleit@1.0.0',
  'has-flag@4.0.0',
  'rimraf@3.0.2',
  'querystring@0.2.0',
  'punycode@1.3.2',
  'cli-truncate@2.1.0',
  'buffer-crc32@0.2.13',
  ... 73 more items
]

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
